### PR TITLE
bootd: Roles add access for com.webos.service.activitymanager.client

### DIFF
--- a/files/sysbus/com.webos.bootd.role.json.in
+++ b/files/sysbus/com.webos.bootd.role.json.in
@@ -12,7 +12,8 @@
                 "com.webos.service.config",
                 "com.webos.service.connectionmanager",
                 "com.webos.settingsservice",
-                "com.webos.surfacemanager"
+                "com.webos.surfacemanager",
+                "com.webos.service.activitymanager.client"
             ]
         }
     ]


### PR DESCRIPTION
Fixes:

Jun 17 09:35:41 qemux86-64 ls-hubd[254]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.service.activitymanager.client","SRC_APP_ID":"com.webos.bootManager","EXE":"/usr/sbin/bootd","PID":418} "com.webos.bootManager" does not have sufficient outbound permissions to communicate with "com.webos.service.activitymanager.client" (cmdline: /usr/sbin/bootd)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>